### PR TITLE
Implementation ecc mul var

### DIFF
--- a/src/circuit/ecc/general_ecc/mul.rs
+++ b/src/circuit/ecc/general_ecc/mul.rs
@@ -1,0 +1,161 @@
+use super::AssignedPoint;
+use crate::circuit::ecc::general_ecc::{GeneralEccChip, GeneralEccInstruction};
+use crate::circuit::main_gate::{CombinationOption, MainGateInstructions, Term};
+use crate::circuit::{Assigned, AssignedCondition, AssignedInteger};
+use crate::rns::{big_to_fe, fe_to_big};
+use crate::NUMBER_OF_LIMBS;
+use halo2::arithmetic::{CurveAffine, FieldExt};
+use halo2::circuit::Region;
+use halo2::plonk::Error;
+use num_bigint::BigUint as big_uint;
+use num_integer::Integer;
+
+struct ScalarTuple<F: FieldExt> {
+    h: AssignedCondition<F>,
+    l: AssignedCondition<F>,
+}
+
+impl<Emulated: CurveAffine, F: FieldExt> GeneralEccChip<Emulated, F> {
+    fn decompose(
+        &self,
+        region: &mut Region<'_, F>,
+        input: AssignedInteger<F>,
+        offset: &mut usize,
+    ) -> Result<(AssignedCondition<F>, Vec<ScalarTuple<F>>), Error> {
+        // Algorithm's limitation.
+        assert!(input.bit_len_limb % 2 == 0);
+
+        let zero = F::zero();
+        let one = F::one();
+        let two = F::from(2u64);
+        let four = F::from(4u64);
+        let main_gate = self.main_gate();
+
+        let mut res = Vec::with_capacity(NUMBER_OF_LIMBS * input.bit_len_limb / 2);
+        let mut limb_carry_bits = vec![];
+
+        // For each two bits,
+        // b00: 0
+        // b01: 1
+        // b10: 2
+        // b11: -1
+        //
+        // d_next * 4 + lb + lh * 2 - lb * lh * 4 = d_curr
+        //
+        // Witness layout:
+        // | A   | B   | C     | D  |
+        // | --- | --- | ----- | -- |
+        // | lb0 | hb0 | limb0 | 0  |
+        // | lb1 | hb1 | 0     | d1 |
+        // | lb2 | hb2 | 0     | d2 |
+        // ...
+        //
+        // On next limb
+        // | lb0' | hb0' | limb1 | d0' |
+        // | lb1' | hb1' | 0     | d1' |
+        // | lb2' | hb2' | 0     | d2' |
+        // ...
+        //
+        // At last
+        // | lbn | hbn | 0 | dn |
+        // | 0   | 0   | 0 | d  |
+
+        let mut rem = big_uint::from(0u64);
+        for idx in 0..NUMBER_OF_LIMBS {
+            let last_limb_rem = rem.clone();
+            rem = match input.limb(idx).value() {
+                Some(v) => rem + fe_to_big(v),
+                _ => rem,
+            };
+
+            for i in 0..(input.bit_len_limb / 2) {
+                let shift = |rem: big_uint, carry| {
+                    if rem.is_odd() {
+                        (rem >> 1, one.clone(), carry)
+                    } else {
+                        (rem >> 1, zero.clone(), 0u64)
+                    }
+                };
+
+                let d = if i == 0 { big_to_fe(last_limb_rem.clone()) } else { big_to_fe(rem.clone()) };
+                let carry = 1u64;
+                let (rem_shifted, a, carry) = shift(rem, carry);
+                let (rem_shifted, b, carry) = shift(rem_shifted, carry);
+                rem = rem_shifted + carry;
+
+                let (cell_a, cell_b, _, cell_d) = main_gate.combine(
+                    region,
+                    Term::Unassigned(Some(a), one),
+                    Term::Unassigned(Some(b), two),
+                    if i == 0 { Term::Assigned(&input.limbs[idx], -one) } else { Term::Zero },
+                    Term::Unassigned(Some(d), -one),
+                    zero,
+                    offset,
+                    CombinationOption::CombineToNextMulN(four, -four),
+                )?;
+
+                res.push(ScalarTuple {
+                    h: AssignedCondition::new(cell_b, Some(b)),
+                    l: AssignedCondition::new(cell_a, Some(a)),
+                });
+
+                if idx != 0 && i == 0 {
+                    limb_carry_bits.push(AssignedCondition::new(cell_d, Some(d)));
+                };
+            }
+        }
+
+        let d = big_to_fe(rem);
+        let (_, _, _, cell_d) = main_gate.combine(
+            region,
+            Term::Zero,
+            Term::Zero,
+            Term::Zero,
+            Term::Unassigned(Some(d), zero),
+            zero,
+            offset,
+            CombinationOption::SingleLinerAdd,
+        )?;
+
+        let rem = AssignedCondition::new(cell_d, Some(d));
+        limb_carry_bits.push(rem.clone());
+
+        for limb_carry_bit in limb_carry_bits.iter() {
+            main_gate.assert_bit(region, limb_carry_bit.clone(), offset)?;
+        }
+
+        for x in res.iter() {
+            main_gate.assert_bit(region, x.h.clone(), offset)?;
+            main_gate.assert_bit(region, x.l.clone(), offset)?;
+        }
+
+        Ok((rem, res))
+    }
+
+    pub(crate) fn _mul_var(
+        &self,
+        region: &mut Region<'_, F>,
+        p: AssignedPoint<F>,
+        e: AssignedInteger<F>,
+        offset: &mut usize,
+    ) -> Result<AssignedPoint<F>, Error> {
+        let p_neg = self.neg(region, &p, offset)?;
+        let p_double = self.double(region, &p, offset)?;
+        let (rem, selector) = self.decompose(region, e, offset)?;
+        let mut acc = self.select_or_assign(region, &rem, &p, Emulated::identity(), offset)?;
+
+        for di in selector.iter().rev() {
+            // 0b01 - p, 0b00 - identity
+            let b0 = self.select_or_assign(region, &di.l, &p, Emulated::identity(), offset)?;
+            // 0b11 - p_neg, 0b10 - p_double
+            let b1 = self.select(region, &di.l, &p_neg, &p_double, offset)?;
+            let a = self.select(region, &di.h, &b1, &b0, offset)?;
+
+            acc = self.double(region, &acc, offset)?;
+            acc = self.double(region, &acc, offset)?;
+            acc = self.add(region, &acc, &a, offset)?;
+        }
+
+        Ok(acc)
+    }
+}

--- a/src/circuit/integer.rs
+++ b/src/circuit/integer.rs
@@ -17,6 +17,7 @@ mod assign;
 mod div;
 mod invert;
 mod mul;
+mod neg;
 mod reduce;
 mod square;
 mod sub;
@@ -64,6 +65,7 @@ pub trait IntegerInstructions<N: FieldExt> {
     fn add(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn add_constant(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &Integer<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn sub(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
+    fn neg(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn mul(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn square(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn div(
@@ -119,6 +121,10 @@ impl<W: FieldExt, N: FieldExt> IntegerInstructions<N> for IntegerChip<W, N> {
         self.reduce_if_necessary(region, a, offset)?;
         self.reduce_if_necessary(region, b, offset)?;
         self._sub(region, a, b, offset)
+    }
+
+    fn neg(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error> {
+        self._neg(region, a, offset)
     }
 
     fn mul(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error> {

--- a/src/circuit/integer/neg.rs
+++ b/src/circuit/integer/neg.rs
@@ -1,0 +1,30 @@
+use super::IntegerChip;
+use crate::circuit::main_gate::MainGateInstructions;
+use crate::circuit::{AssignedInteger, AssignedLimb};
+use crate::rns::{fe_to_big, Common};
+use crate::NUMBER_OF_LIMBS;
+use halo2::arithmetic::FieldExt;
+use halo2::circuit::Region;
+use halo2::plonk::Error;
+
+impl<W: FieldExt, N: FieldExt> IntegerChip<W, N> {
+    pub(crate) fn _neg(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error> {
+        let main_gate = self.main_gate();
+
+        let aux: Vec<N> = self.rns.aux.limbs();
+        let aux_native = self.rns.aux.native();
+        let mut b_limbs: Vec<AssignedLimb<N>> = Vec::with_capacity(NUMBER_OF_LIMBS);
+
+        for idx in 0..NUMBER_OF_LIMBS {
+            let a_limb = a.limb(idx);
+            let aux = aux[idx];
+            let b_limb = main_gate.neg_with_constant(region, a_limb, aux, offset)?;
+
+            b_limbs.push(AssignedLimb::<N>::new(b_limb.cell, b_limb.value, fe_to_big(aux)))
+        }
+
+        let b_native = main_gate.neg_with_constant(region, a.native(), aux_native, offset)?;
+
+        Ok(AssignedInteger::new(b_limbs, b_native, self.rns.bit_len_limb))
+    }
+}


### PR DESCRIPTION
We use variant w-naf (with w = 2) to implement ecc mul which needs 256 * (3 / 2) ecc add.
Here is an example of `p * s`.
At first, we decompose `s` into 2-bit vector with a carry bit.
Suppose `s mod 4 = bit_low + bit_high * 2`.
Unlike normal binary decompose, when we meet 0b11, it doesn't means 3 but (-1). So the constraints looks like,
`bit_low + bit_high * 2 - 4 * bit_low * bit_high + 4 * s' = s`.
At last, `carry = s_final`.

Then we iterate all 2-bit pairs from most significant pair.
```
for i in 0..256 {
  pairs[i] = s % 4;
  s = s / 4 + pairs[i] / 3;
}
let carry = s;
let acc = carry ? p : identity;
for pair of pairs.rev() {
  let s = match pair {
    0b00 => identity,
    0b01 => p,
    0b10 => p + p,
    0b11 => -p
  }
  acc = acc * 4 + s
}
```
