### PR TITLE
Optimize ecc mul with add_zero_or_neq

### DIFF
--- a/src/circuit/ecc/general_ecc.rs
+++ b/src/circuit/ecc/general_ecc.rs
@@ -66,6 +66,14 @@ pub trait GeneralEccInstruction<Emulated: CurveAffine, N: FieldExt> {
 
     fn add(&self, region: &mut Region<'_, N>, p0: &AssignedPoint<N>, p1: &AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error>;
 
+    fn add_identity_or_neq(
+        &self,
+        region: &mut Region<'_, N>,
+        p0: &AssignedPoint<N>,
+        p1: &AssignedPoint<N>,
+        offset: &mut usize,
+    ) -> Result<AssignedPoint<N>, Error>;
+
     fn add_incomplete(
         &self,
         region: &mut Region<'_, N>,
@@ -279,6 +287,16 @@ impl<Emulated: CurveAffine, N: FieldExt> GeneralEccInstruction<Emulated, N> for 
 
     fn add(&self, region: &mut Region<'_, N>, p0: &AssignedPoint<N>, p1: &AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error> {
         self._add(region, p0, p1, offset)
+    }
+
+    fn add_identity_or_neq(
+        &self,
+        region: &mut Region<'_, N>,
+        p0: &AssignedPoint<N>,
+        p1: &AssignedPoint<N>,
+        offset: &mut usize,
+    ) -> Result<AssignedPoint<N>, Error> {
+        self._add_identity_or_neq(region, p0, p1, offset)
     }
 
     fn add_incomplete(

--- a/src/circuit/ecc/general_ecc/mul.rs
+++ b/src/circuit/ecc/general_ecc/mul.rs
@@ -1,4 +1,5 @@
 use super::AssignedPoint;
+use super::IntegerInstructions;
 use crate::circuit::ecc::general_ecc::{GeneralEccChip, GeneralEccInstruction};
 use crate::circuit::main_gate::{CombinationOption, MainGateInstructions, Term};
 use crate::circuit::{Assigned, AssignedCondition, AssignedInteger};
@@ -139,6 +140,8 @@ impl<Emulated: CurveAffine, F: FieldExt> GeneralEccChip<Emulated, F> {
         e: AssignedInteger<F>,
         offset: &mut usize,
     ) -> Result<AssignedPoint<F>, Error> {
+        let e = self.scalar_field_chip().reduce(region, &e, offset)?;
+
         let p_neg = self.neg(region, &p, offset)?;
         let p_double = self.double(region, &p, offset)?;
         let (rem, selector) = self.decompose(region, e, offset)?;
@@ -153,7 +156,7 @@ impl<Emulated: CurveAffine, F: FieldExt> GeneralEccChip<Emulated, F> {
 
             acc = self.double(region, &acc, offset)?;
             acc = self.double(region, &acc, offset)?;
-            acc = self.add(region, &acc, &a, offset)?;
+            acc = self.add_identity_or_neq(region, &acc, &a, offset)?;
         }
 
         Ok(acc)


### PR DESCRIPTION
During the sum of the window in ecc mul, e.g.

```
acc = identity or p
foreach window
    acc = acc * 4 + p * window
```
The `window` is one of `0`, `-1`, `1`, `2`.
Thus the `acc * 4` can not be equal to `p * window` except they are both identity.
We can optimize the addition by eliminating the branch of curvature called `add_identity_or_neq()`.
It can reduce a lot of contraints (from > 200k to < 160k in my test), please help confirm.