### PR TITLE
Optimize ecc mul with add_with_curvature

### DIFF
--- a/src/circuit/ecc/base_field_ecc.rs
+++ b/src/circuit/ecc/base_field_ecc.rs
@@ -177,7 +177,7 @@ impl<C: CurveAffine> BaseFieldEccInstruction<C> for BaseFieldEccChip<C> {
         let integer_chip = self.integer_chip();
         let x = integer_chip.cond_select(region, &p1.x, &p2.x, c, offset)?;
         let y = integer_chip.cond_select(region, &p1.y, &p2.y, c, offset)?;
-        let c: AssignedCondition<C::ScalarExt> = main_gate.cond_select(region, p1.z.clone(), p2.z.clone(), c, offset)?.into();
+        let c: AssignedCondition<C::ScalarExt> = main_gate.cond_select(region, &p1.z, &p2.z, c, offset)?.into();
         Ok(AssignedPoint::new(x, y, c))
     }
 

--- a/src/circuit/ecc/general_ecc.rs
+++ b/src/circuit/ecc/general_ecc.rs
@@ -228,7 +228,7 @@ impl<Emulated: CurveAffine, N: FieldExt> GeneralEccInstruction<Emulated, N> for 
         offset: &mut usize,
     ) -> Result<AssignedPoint<N>, Error> {
         let point = &self.select_incomplete(region, c, &p1.into(), &p2.into(), offset)?;
-        let c = self.main_gate().cond_select(region, p1.z.clone(), p2.z.clone(), c, offset)?.into();
+        let c = self.main_gate().cond_select(region, &p1.z, &p2.z, c, offset)?.into();
         Ok(AssignedPoint::from_impcomplete(point, &c))
     }
 

--- a/src/circuit/integer.rs
+++ b/src/circuit/integer.rs
@@ -323,7 +323,7 @@ impl<W: FieldExt, N: FieldExt> IntegerInstructions<N> for IntegerChip<W, N> {
 
         let mut limbs: Vec<AssignedLimb<N>> = Vec::with_capacity(NUMBER_OF_LIMBS);
         for i in 0..NUMBER_OF_LIMBS {
-            let res = main_gate.cond_select(region, a.limb(i), b.limb(i), cond, offset)?;
+            let res = main_gate.cond_select(region, &a.limb(i), &b.limb(i), cond, offset)?;
 
             let max_val = if a.limbs[i].max_val > b.limbs[i].max_val {
                 a.limbs[i].max_val.clone()
@@ -334,7 +334,7 @@ impl<W: FieldExt, N: FieldExt> IntegerInstructions<N> for IntegerChip<W, N> {
             limbs.push(res.to_limb(max_val));
         }
 
-        let native_value = main_gate.cond_select(region, a.native(), b.native(), cond, offset)?;
+        let native_value = main_gate.cond_select(region, &a.native(), &b.native(), cond, offset)?;
 
         Ok(self.new_assigned_integer(limbs, native_value))
     }

--- a/src/circuit/main_gate.rs
+++ b/src/circuit/main_gate.rs
@@ -133,8 +133,8 @@ pub trait MainGateInstructions<F: FieldExt> {
     fn cond_select(
         &self,
         region: &mut Region<'_, F>,
-        a: impl Assigned<F>,
-        b: impl Assigned<F>,
+        a: &impl Assigned<F>,
+        b: &impl Assigned<F>,
         cond: &AssignedCondition<F>,
         offset: &mut usize,
     ) -> Result<AssignedValue<F>, Error>;
@@ -745,8 +745,8 @@ impl<F: FieldExt> MainGateInstructions<F> for MainGate<F> {
     fn cond_select(
         &self,
         region: &mut Region<'_, F>,
-        a: impl Assigned<F>,
-        b: impl Assigned<F>,
+        a: &impl Assigned<F>,
+        b: &impl Assigned<F>,
         cond: &AssignedCondition<F>,
         offset: &mut usize,
     ) -> Result<AssignedValue<F>, Error> {
@@ -771,8 +771,8 @@ impl<F: FieldExt> MainGateInstructions<F> for MainGate<F> {
         // a - b - dif = 0
         let (_, _, _, dif_cell) = self.combine(
             region,
-            Term::assigned_to_add(&a),
-            Term::assigned_to_sub(&b),
+            Term::assigned_to_add(a),
+            Term::assigned_to_sub(b),
             Term::Zero,
             Term::unassigned_to_sub(dif),
             F::zero(),
@@ -787,7 +787,7 @@ impl<F: FieldExt> MainGateInstructions<F> for MainGate<F> {
             region,
             Term::assigned_to_mul(dif),
             Term::assigned_to_mul(cond),
-            Term::assigned_to_add(&b),
+            Term::assigned_to_add(b),
             Term::unassigned_to_sub(res),
             F::zero(),
             offset,
@@ -1757,7 +1757,7 @@ mod tests {
                     let a = main_gate.assign_value(&mut region, &a, super::MainGateColumn::A, &mut offset)?;
                     let b = main_gate.assign_value(&mut region, &b, super::MainGateColumn::A, &mut offset)?;
                     let cond: AssignedCondition<F> = main_gate.assign_value(&mut region, &cond, super::MainGateColumn::A, &mut offset)?.into();
-                    let selected = main_gate.cond_select(&mut region, a, b.clone(), &cond, &mut offset)?;
+                    let selected = main_gate.cond_select(&mut region, &a, &b, &cond, &mut offset)?;
                     main_gate.assert_equal(&mut region, b, selected, &mut offset)?;
 
                     let a = F::rand();
@@ -1771,7 +1771,7 @@ mod tests {
                     let a = main_gate.assign_value(&mut region, &a, super::MainGateColumn::A, &mut offset)?;
                     let b = main_gate.assign_value(&mut region, &b, super::MainGateColumn::A, &mut offset)?;
                     let cond: AssignedCondition<F> = main_gate.assign_value(&mut region, &cond, super::MainGateColumn::A, &mut offset)?.into();
-                    let selected = main_gate.cond_select(&mut region, a.clone(), b, &cond, &mut offset)?;
+                    let selected = main_gate.cond_select(&mut region, &a, &b, &cond, &mut offset)?;
                     main_gate.assert_equal(&mut region, a, selected, &mut offset)?;
 
                     let a = F::rand();


### PR DESCRIPTION
We can reuse the curvature of ecc point `p` if it is added in multiple times.
The `offset` of `test_general_ecc_multiplication_circuit` can be reduced to `176288`.

In _mul_var():
```
    loop {
        acc = double(acc);
        acc = double(acc);
        acc = add(acc, case(window_value, identity, p, p_double, p_neg);
    }
```
->
```
    loop {
        acc = double(acc);
        acc = double(acc);
        acc = add_with_curvature(
            acc,
            select(window_value, identity, p, p_double, p_neg),
            select(window_value, identity_curvature, ...));
    }
```