### PR TITLE
Fix `Integer` features

### DIFF
--- a/integer/Cargo.toml
+++ b/integer/Cargo.toml
@@ -20,5 +20,5 @@ secp256k1 = { path = "../ecc/secp256k1", default-features = false }
 
 [features]
 default = ["zcash"]
-kzg = ["maingate/kzg", "secp256k1/kzg"]
-zcash = ["maingate/zcash", "secp256k1/zcash"]
+kzg = ["maingate/kzg"]
+zcash = ["maingate/zcash"]

--- a/integer/Cargo.toml
+++ b/integer/Cargo.toml
@@ -13,12 +13,13 @@ rand = "0.8"
 group = "0.11"
 subtle = { version = "2.3", default-features = false }
 cfg-if = "0.1"
+secp256k1 = {path = "../ecc/secp256k1", default-features = false }
 
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false }
-secp256k1 = { path = "../ecc/secp256k1", default-features = false }
+
 
 [features]
 default = ["zcash"]
-kzg = ["maingate/kzg"]
-zcash = ["maingate/zcash"]
+kzg = ["maingate/kzg", "secp256k1/kzg"]
+zcash = ["maingate/zcash", "secp256k1/zcash"]


### PR DESCRIPTION
Removes left over  feature from a previous version `secp256k1` .
Closes #23 .