### PR TITLE
Add github action for KZG test; fix bool to F

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-test-IPA:
 
     runs-on: ubuntu-latest
 
@@ -20,3 +20,14 @@ jobs:
       run: cargo build --verbose --release
     - name: Run tests
       run: cargo test --verbose --release
+
+  build-test-KZG:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --no-default-features --features kzg --verbose --release
+    - name: Run tests
+      run: cargo test --no-default-features --features kzg --verbose --release

--- a/ecc/secp256k1/src/curves.rs
+++ b/ecc/secp256k1/src/curves.rs
@@ -667,6 +667,25 @@ macro_rules! new_curve_impl {
             fn b() -> Self::Base {
                 $name::curve_constant_b()
             }
+
+            fn get_endomorphism_base(_: &Self) -> Self {
+                todo!()
+            }
+
+            fn get_endomorphism_scalars(_: &<Self as CurveAffine>::ScalarExt) -> (u128, u128) {
+                todo!()
+            }
+
+            fn batch_add<const COMPLETE: bool, const LOAD_POINTS: bool>(
+                _: &mut [Self],
+                _: &[u32],
+                _: usize,
+                _: usize,
+                _: &[Self],
+                _: &[u32],
+            ) {
+                todo!()
+            }
         }
 
         impl Default for $name_affine {

--- a/ecdsa/src/ecdsa.rs
+++ b/ecdsa/src/ecdsa.rs
@@ -158,10 +158,6 @@ mod tests {
     use rand::thread_rng;
     use std::marker::PhantomData;
 
-    #[cfg(not(feature = "kzg"))]
-    use group::ff::PrimeField;
-
-    #[cfg(feature = "kzg")]
     use crate::halo2::arithmetic::BaseExt;
 
     const BIT_LEN_LIMB: usize = 68;
@@ -249,15 +245,8 @@ mod tests {
             let sig_point = generator * randomness;
             let x = sig_point.to_affine().coordinates().unwrap().x().clone();
 
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "kzg")] {
-                    let x_repr = &mut Vec::with_capacity(32);
-                    x.write(x_repr)?;
-                } else {
-                    let mut x_repr = [0u8; 32];
-                    x_repr.copy_from_slice(x.to_repr().as_ref());
-                }
-            }
+            let x_repr = &mut Vec::with_capacity(32);
+            x.write(x_repr)?;
 
             let mut x_bytes = [0u8; 64];
             x_bytes[..32].copy_from_slice(&x_repr[..]);

--- a/halo2wrong/Cargo.toml
+++ b/halo2wrong/Cargo.toml
@@ -23,7 +23,7 @@ optional = true
 [dependencies.halo2_kzg]
 package = "halo2_proofs"
 git = "https://github.com/appliedzkp/halo2.git"
-rev = "fea000f5ce1a573bd61368d7465a3caaff94cf92"
+tag = "v2022_05_06"
 optional = true
 
 [features]

--- a/halo2wrong/Cargo.toml
+++ b/halo2wrong/Cargo.toml
@@ -23,7 +23,7 @@ optional = true
 [dependencies.halo2_kzg]
 package = "halo2_proofs"
 git = "https://github.com/appliedzkp/halo2.git"
-tag = "v2022_05_06"
+tag = "v2022_05_09"
 optional = true
 
 [features]

--- a/maingate/src/instructions.rs
+++ b/maingate/src/instructions.rs
@@ -980,7 +980,7 @@ pub trait MainGateInstructions<F: FieldExt, const WIDTH: usize>: Chip<F> {
             use num_traits::{One, Zero};
             let value = &fe_to_big(value);
             let half = big_to_fe(value / 2usize);
-            let sign = (value & BigUint::one() != BigUint::zero()).into();
+            let sign = ((value & BigUint::one() != BigUint::zero()) as u64).into();
             (sign, half)
         });
 


### PR DESCRIPTION
When testing with the `kzg` feature, I encountered an error when rust tries to convert a `bool` to `F`.  I just fixed it by converting the `bool` into `u64` (as `FieldExt` implements `From<u64>` via `ff::PrimeField`).
```
$ cargo test check --no-default-features --features kzg
   Compiling maingate v0.1.0 (/home/dev/git/zkevm/halo2wrong/maingate)
error[E0277]: the trait bound `F: From<bool>` is not satisfied
   --> maingate/src/instructions.rs:983:68
    |
983 |             let sign = (value & BigUint::one() != BigUint::zero()).into();
    |                                                                    ^^^^ the trait `From<bool>` is not implemented for `F`
    |
    = note: required because of the requirements on the impl of `Into<F>` for `bool`
help: consider further restricting this bound
    |
176 | pub trait MainGateInstructions<F: FieldExt + std::convert::From<bool>, const WIDTH: usize>: Chip<F> {
    |                                            ++++++++++++++++++++++++++

For more information about this error, try `rustc --explain E0277`.
error: could not compile `maingate` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```
I've also fixed a small build error that was happening with the `zcash` feature enabled.
I've also added a github action to build and test with the `kzg` feature.
And finally I've bumped the `appliedzkp/halo2` dependency to match the one used in the `zkevm-circuits`; let me know if that's OK or if there's any problem with it!